### PR TITLE
php7 Klasse "String" durch Contao Klasse "StringUtil" ersetzt

### DIFF
--- a/assets/.htaccess
+++ b/assets/.htaccess
@@ -1,2 +1,7 @@
-order allow,deny
-allow from all
+<IfModule !mod_authz_core.c>
+  Order allow,deny
+  Allow from all
+</IfModule>
+<IfModule mod_authz_core.c>
+  Require all granted
+</IfModule>

--- a/elements/ContentDownloadarchive.php
+++ b/elements/ContentDownloadarchive.php
@@ -148,7 +148,7 @@ class ContentDownloadarchive extends \ContentElement
 	protected function compile()
 	{
 		global $objPage;
-        $this->import('String');
+        $this->import('StringUtil');
 		
 		$arrDownloadFiles = array();
 		
@@ -171,14 +171,14 @@ class ContentDownloadarchive extends \ContentElement
                 // Clean the RTE output
                 if ($objPage->outputFormat == 'xhtml')
                 {
-                    $arrFile['description'] = \String::toXhtml($arrFile['description']);
+                    $arrFile['description'] = \StringUtil::toXhtml($arrFile['description']);
                 }
                 else
                 {
-                    $arrFile['description'] = \String::toHtml5($arrFile['description']);
+                    $arrFile['description'] = \StringUtil::toHtml5($arrFile['description']);
                 }
 
-                $arrFile['description'] = \String::encodeEmail($arrFile['description']);
+                $arrFile['description'] = \StringUtil::encodeEmail($arrFile['description']);
 				$arrFile['css'] = ( $objArchive->class != "" ) ? $objArchive->class . ' ' : '';
 
 				$arrFile['ctime'] = $objFile->ctime;
@@ -276,7 +276,7 @@ class ContentDownloadarchive extends \ContentElement
 			$arrFiles = array_slice($arrFiles,$offset,$this->perPage);
 			
 			// Add pagination menu
-			$objPagination = new Pagination($length, $this->perPage);
+			$objPagination = new \Pagination($length, $this->perPage);
 			$this->Template->pagination = $objPagination->generate("\n  ");
 			
 			$length = count($arrFiles);

--- a/modules/ModuleDownloadarchive.php
+++ b/modules/ModuleDownloadarchive.php
@@ -148,7 +148,7 @@ class ModuleDownloadarchive extends \Module
 	protected function compile()
 	{
 		global $objPage;
-        $this->import('String');
+        $this->import('StringUtil');
 		
 		$arrDownloadFiles = array();
 		
@@ -171,14 +171,14 @@ class ModuleDownloadarchive extends \Module
                 // Clean the RTE output
                 if ($objPage->outputFormat == 'xhtml')
                 {
-                    $arrFile['description'] = \String::toXhtml($arrFile['description']);
+                    $arrFile['description'] = \StringUtil::toXhtml($arrFile['description']);
                 }
                 else
                 {
-                    $arrFile['description'] = \String::toHtml5($arrFile['description']);
+                    $arrFile['description'] = \StringUtil::toHtml5($arrFile['description']);
                 }
 
-                $arrFile['description'] = \String::encodeEmail($arrFile['description']);
+                $arrFile['description'] = \StringUtil::encodeEmail($arrFile['description']);
 				$arrFile['css'] = ( $objArchive->class != "" ) ? $objArchive->class . ' ' : '';
 
 				$arrFile['ctime'] = $objFile->ctime;
@@ -276,7 +276,7 @@ class ModuleDownloadarchive extends \Module
 			$arrFiles = array_slice($arrFiles,$offset,$this->perPage);
 			
 			// Add pagination menu
-			$objPagination = new Pagination($length, $this->perPage);
+			$objPagination = new \Pagination($length, $this->perPage);
 			$this->Template->pagination = $objPagination->generate("\n  ");
 			
 			$length = count($arrFiles);


### PR DESCRIPTION
Um die Kompatibilität zu php7 zu gewährleisten sollte die Klasse "String" durch "StringUtil" aus Contao ersetzt werden. Leider kann ich derzeit nicht testen, ob diese Änderung auch mit php ~5 funktioniert.

Das composer.json gibt an, dass die Erweiterung mit php7 funktioniert, was sie mit der "String"-Klasse unter php7 leider nicht tut. Dieser Pull-Request sollte das Problem beheben.

Weiterhin wurde der Pagination Aufruf angepasst.